### PR TITLE
Add dataset version 0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+assets/*.tar.gz filter=lfs diff=lfs merge=lfs -text

--- a/assets/ver0.tar.gz
+++ b/assets/ver0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7492abdc9f7d82733436fd1e1e638b6b8176207f54f572c8fea8069eb9e51b8
+size 458084864


### PR DESCRIPTION
Format is .tar.gz archive of folder ver0 (future versions would be verX) with images with names Y.png, where Y is global index of an image across all versions.

Size of dataset version 0 is 169 images.

Set up git-lfs to track all .tar.gz archives in assets folder.