### PR TITLE
Enable pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.5.0
+  hooks:
+  - id: end-of-file-fixer
+  - id: trailing-whitespace
+  - id: check-added-large-files
+  - id: check-merge-conflict
+    args: [--assume-in-merge]
+  - id: mixed-line-ending
+    args: [--fix=no]


### PR DESCRIPTION
The initial list of used hooks is:

* fix end of files
* trim trailing whitespace
* check for added large files (that aren't tracked by git-lfs)
* check for merge conflicts
* mixed line endings